### PR TITLE
fix(sec): upgrade mysql-connector-java to 8.0.28

### DIFF
--- a/zlt-job/pom.xml
+++ b/zlt-job/pom.xml
@@ -26,7 +26,7 @@
 		<jetty-server.version>9.2.26.v20180806</jetty-server.version>
 		<spring-boot.version>1.5.18.RELEASE</spring-boot.version>
 		<mybatis-spring-boot-starter.version>1.3.2</mybatis-spring-boot-starter.version>
-		<mysql-connector-java.version>8.0.13</mysql-connector-java.version>
+		<mysql-connector-java.version>8.0.28</mysql-connector-java.version>
 		<spring.version>4.3.21.RELEASE</spring.version>
 		<slf4j-api.version>1.7.25</slf4j-api.version>
 		<freemarker.version>2.3.28</freemarker.version>


### PR DESCRIPTION
Upgrade mysql-connector-java 8.0.13  to  8.0.28 for vulnerability fix:
- [CVE-2019-2692](https://www.oscs1024.com/hd/MPS-2019-4430)
- [CVE-2021-2471](https://www.oscs1024.com/hd/MPS-2021-45509)
- [CVE-2022-21363](https://www.oscs1024.com/hd/MPS-2021-36587)