### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.12.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.zlt</groupId>
     <artifactId>central-platform</artifactId>
@@ -50,7 +48,7 @@
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <dubbo.version>2.7.8</dubbo.version>
         <curator.version>5.1.0</curator.version>
-        <jackson-databind.version>2.12.4</jackson-databind.version>
+        <jackson-databind.version>2.12.6.1</jackson-databind.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <zuul.version>2.2.9.RELEASE</zuul.version>
         <aws-java-sdk-s3.version>1.12.40</aws-java-sdk-s3.version>


### PR DESCRIPTION
### What happened？
There are 49 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.9.8
- [CVE-2019-14540](https://www.oscs1024.com/hd/CVE-2019-14540)
- [CVE-2019-16335](https://www.oscs1024.com/hd/CVE-2019-16335)
- [CVE-2019-16942](https://www.oscs1024.com/hd/CVE-2019-16942)
- [CVE-2019-16943](https://www.oscs1024.com/hd/CVE-2019-16943)
- [CVE-2019-17267](https://www.oscs1024.com/hd/CVE-2019-17267)
- [CVE-2019-17531](https://www.oscs1024.com/hd/CVE-2019-17531)
- [CVE-2019-12086](https://www.oscs1024.com/hd/CVE-2019-12086)
- [CVE-2019-12814](https://www.oscs1024.com/hd/CVE-2019-12814)
- [CVE-2019-12384](https://www.oscs1024.com/hd/CVE-2019-12384)
- [CVE-2019-14379](https://www.oscs1024.com/hd/CVE-2019-14379)
- [CVE-2019-14439](https://www.oscs1024.com/hd/CVE-2019-14439)
- [CVE-2019-20330](https://www.oscs1024.com/hd/CVE-2019-20330)
- [CVE-2020-24616](https://www.oscs1024.com/hd/CVE-2020-24616)
- [CVE-2020-24750](https://www.oscs1024.com/hd/CVE-2020-24750)
- [CVE-2020-35490](https://www.oscs1024.com/hd/CVE-2020-35490)
- [CVE-2020-35491](https://www.oscs1024.com/hd/CVE-2020-35491)
- [CVE-2020-35728](https://www.oscs1024.com/hd/CVE-2020-35728)
- [CVE-2020-8840](https://www.oscs1024.com/hd/CVE-2020-8840)
- [CVE-2020-10650](https://www.oscs1024.com/hd/CVE-2020-10650)
- [CVE-2020-9546](https://www.oscs1024.com/hd/CVE-2020-9546)
- [CVE-2020-9548](https://www.oscs1024.com/hd/CVE-2020-9548)
- [CVE-2019-14892](https://www.oscs1024.com/hd/CVE-2019-14892)
- [CVE-2019-14893](https://www.oscs1024.com/hd/CVE-2019-14893)
- [CVE-2020-10672](https://www.oscs1024.com/hd/CVE-2020-10672)
- [CVE-2020-10673](https://www.oscs1024.com/hd/CVE-2020-10673)
- [CVE-2020-10968](https://www.oscs1024.com/hd/CVE-2020-10968)
- [CVE-2020-10969](https://www.oscs1024.com/hd/CVE-2020-10969)
- [CVE-2020-11111](https://www.oscs1024.com/hd/CVE-2020-11111)
- [CVE-2020-11112](https://www.oscs1024.com/hd/CVE-2020-11112)
- [CVE-2020-11113](https://www.oscs1024.com/hd/CVE-2020-11113)
- [CVE-2020-11619](https://www.oscs1024.com/hd/CVE-2020-11619)
- [CVE-2020-11620](https://www.oscs1024.com/hd/CVE-2020-11620)
- [CVE-2020-14061](https://www.oscs1024.com/hd/CVE-2020-14061)
- [CVE-2020-14062](https://www.oscs1024.com/hd/CVE-2020-14062)
- [CVE-2020-14060](https://www.oscs1024.com/hd/CVE-2020-14060)
- [CVE-2020-14195](https://www.oscs1024.com/hd/CVE-2020-14195)
- [CVE-2020-36179](https://www.oscs1024.com/hd/CVE-2020-36179)
- [CVE-2020-36180](https://www.oscs1024.com/hd/CVE-2020-36180)
- [CVE-2020-36182](https://www.oscs1024.com/hd/CVE-2020-36182)
- [CVE-2020-36183](https://www.oscs1024.com/hd/CVE-2020-36183)
- [CVE-2020-36184](https://www.oscs1024.com/hd/CVE-2020-36184)
- [CVE-2020-36185](https://www.oscs1024.com/hd/CVE-2020-36185)
- [CVE-2020-36186](https://www.oscs1024.com/hd/CVE-2020-36186)
- [CVE-2020-36187](https://www.oscs1024.com/hd/CVE-2020-36187)
- [CVE-2020-36188](https://www.oscs1024.com/hd/CVE-2020-36188)
- [CVE-2020-36189](https://www.oscs1024.com/hd/CVE-2020-36189)
- [CVE-2021-20190](https://www.oscs1024.com/hd/CVE-2021-20190)
- [MPS-2022-12433](https://www.oscs1024.com/hd/MPS-2022-12433)
- [CVE-2020-36518](https://www.oscs1024.com/hd/CVE-2020-36518)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.9.8 to 2.12.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS