### PR TITLE
fix(sec): upgrade org.apache.commons:commons-configuration2 to 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.zlt</groupId>
     <artifactId>central-platform</artifactId>
@@ -34,7 +32,7 @@
         <poi.version>4.1.1</poi.version>
         <spring-boot-admin.version>2.5.6</spring-boot-admin.version>
         <velocity.version>1.7</velocity.version>
-        <commons-configuration2.version>2.7</commons-configuration2.version>
+        <commons-configuration2.version>2.8</commons-configuration2.version>
         <txlcn.version>5.0.2.RELEASE</txlcn.version>
         <fastdfs-client.version>1.27.2</fastdfs-client.version>
         <userAgent.version>1.21</userAgent.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.commons:commons-configuration2 2.7
- [CVE-2022-33980](https://www.oscs1024.com/hd/CVE-2022-33980)


### What did I do？
Upgrade org.apache.commons:commons-configuration2 from 2.7 to 2.8 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS